### PR TITLE
fix(ui): center-align and reduce font size of level info in Overview tab

### DIFF
--- a/components/ui/RewardsSidebar.tsx
+++ b/components/ui/RewardsSidebar.tsx
@@ -299,9 +299,9 @@ export const RewardsSidebar: React.FC<RewardsDropdownProps> = ({ isOpen, onClose
           </div>
 
           {/* Level Progress Info */}
-          <div className='flex-1 min-w-0'>
+          <div className='flex-1 min-w-0 text-center'>
             <div className='mb-4'>
-              <h3 className='text-2xl font-bold text-white mb-1'>Lvl: {level}</h3>
+              <h3 className='text-xl font-bold text-white mb-1'>Lvl: {level}</h3>
               <p className='text-sm text-gray-300'>
                 {expProgress.current} / {expProgress.next} XP
               </p>


### PR DESCRIPTION

##  Center-Align and Reduce Font Size of Level Info in Overview Tab

Closes #3

### Description
Improves the visual balance and alignment of the level/XP information displayed on the right side of the Overview tab in the Nexus Account panel. The level information was previously left-aligned and used a larger font size that affected the overall visual harmony of the section.

### Changes
- **Centered alignment**: Added `text-center` class to the level progress info container
- **Reduced font size**: Changed level display from `text-2xl` to `text-xl` for better visual balance
- **Improved readability**: All level-related text (level number, XP progress, and XP to next level) now properly centered

### Before & After
**Before:**
- "Lvl: 9" was left-aligned with `text-2xl` font size
- XP information ("471 / 1000 XP") was left-aligned
- "529 XP to next level!" was left-aligned
- Text appeared too prominent for the available space

**After:**
- All level information is center-aligned
- Font size reduced to `text-xl` for better visual harmony
- Improved visual balance within the right-side section
- Better alignment and readability

### Technical Details
**File Modified**: [components/ui/RewardsSidebar.tsx](cci:7://file:///home/lynndabel/demo-suite/components/ui/RewardsSidebar.tsx:0:0-0:0)
- Line 302: Added `text-center` to container div
- Line 304: Changed `text-2xl` to `text-xl` for level heading

### Benefits
✅ Better visual balance in the Overview tab  
✅ Improved alignment and readability  
✅ More harmonious font sizing  
✅ Enhanced user experience  

### Testing
- [x] Verified center alignment of all level text
- [x] Confirmed font size reduction improves visual balance
- [x] Tested in Overview tab of Nexus Account panel
- [x] No breaking changes to functionality
